### PR TITLE
Remove parser restoration methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1164,9 +1164,9 @@
       }
     },
     "remark-redactable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/remark-redactable/-/remark-redactable-0.3.0.tgz",
-      "integrity": "sha512-QFg/i2llV7Mhknd+pf7BxUTFAs4Ts9iyQr1qLdbR5D9E0g6brVQUrEbhujSXctzu2tT/X87Ru56qC4bZvreK+w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-redactable/-/remark-redactable-1.0.0.tgz",
+      "integrity": "sha512-mHBppexkNVXhgARghBLFklZPEUVjgxzM3TV3kclM6Cr4gPZ7UtwPF222OyUVHlikTV5xdb1yM6Tz+m3eEIfkiw==",
       "dev": true
     },
     "remark-stringify": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^5.16.0",
     "remark-html": "^9.0.0",
     "remark-parse": "^6.0.3",
-    "remark-redactable": "0.3.0",
+    "remark-redactable": "1.0.0",
     "remark-stringify": "^6.0.4",
     "tape": "^4.10.2",
     "unified": "^7.1.0",

--- a/src/blockfield.js
+++ b/src/blockfield.js
@@ -9,15 +9,6 @@ module.exports = function blockfield() {
     redact = Parser.prototype.options.redact;
     Parser.prototype.inlineTokenizers[BLOCKFIELD] = tokenizeResourcelink;
 
-    if (Parser.prototype.restorationMethods) {
-      Parser.prototype.restorationMethods[BLOCKFIELD] = function(add, node) {
-        return add({
-          type: 'rawtext',
-          value: `{${node.redactionData}}`
-        });
-      };
-    }
-
     // Run it just before `html`.
     const methods = Parser.prototype.inlineMethods;
     methods.splice(methods.indexOf('html'), 0, BLOCKFIELD);

--- a/src/blockly.js
+++ b/src/blockly.js
@@ -7,15 +7,6 @@ module.exports = function blockly() {
     const Parser = this.Parser;
     redact = Parser.prototype.options.redact;
 
-    if (Parser.prototype.restorationMethods) {
-      Parser.prototype.restorationMethods[BLOCKLY] = function(add, node) {
-        return add({
-          type: 'rawtext',
-          value: node.redactionData
-        });
-      };
-    }
-
     ['inline', 'block'].forEach(type => {
       Parser.prototype[`${type}Tokenizers`][BLOCKLY] = tokenizeBlockly;
       const methods = Parser.prototype[`${type}Methods`];

--- a/src/details.js
+++ b/src/details.js
@@ -30,15 +30,16 @@ let redact;
 
 module.exports = function details() {
   const Parser = this.Parser;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-  const restorationMethods = Parser.prototype.restorationMethods;
+  if (Parser) {
+    const tokenizers = Parser.prototype.blockTokenizers;
+    const methods = Parser.prototype.blockMethods;
 
-  redact = Parser.prototype.options.redact;
-  tokenizers.details = tokenizeDetails;
+    redact = Parser.prototype.options.redact;
+    tokenizers.details = tokenizeDetails;
 
-  /* Run it just before `paragraph`. */
-  methods.splice(methods.indexOf('paragraph'), 0, DETAILS);
+    /* Run it just before `paragraph`. */
+    methods.splice(methods.indexOf('paragraph'), 0, 'details');
+  }
 };
 
 module.exports.restorationMethods = {

--- a/src/details.js
+++ b/src/details.js
@@ -34,34 +34,6 @@ module.exports = function details() {
   const methods = Parser.prototype.blockMethods;
   const restorationMethods = Parser.prototype.restorationMethods;
 
-  if (restorationMethods) {
-    restorationMethods.details = function(add, node, content, children) {
-      const colonCount = node.redactionData;
-      const open = add({
-        type: 'paragraph',
-        children: [
-          {
-            type: 'rawtext',
-            value: `${colon.repeat(colonCount)} details [${content}]`
-          }
-        ]
-      });
-
-      const childNodes = children.map(child => add(child));
-
-      const close = add({
-        type: 'paragraph',
-        children: [
-          {
-            type: 'rawtext',
-            value: colon.repeat(colonCount)
-          }
-        ]
-      });
-
-      return [open, ...childNodes, close];
-    };
-  }
   redact = Parser.prototype.options.redact;
   tokenizers.details = tokenizeDetails;
 

--- a/src/divclass.js
+++ b/src/divclass.js
@@ -71,16 +71,17 @@ let redact;
 
 module.exports = function divclass() {
   const Parser = this.Parser;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-  const restorationMethods = Parser.prototype.restorationMethods;
+  if (Parser) {
+    const tokenizers = Parser.prototype.blockTokenizers;
+    const methods = Parser.prototype.blockMethods;
 
-  redact = Parser.prototype.options.redact;
+    redact = Parser.prototype.options.redact;
 
-  tokenizers.divclass = tokenizeDivclass;
+    tokenizers.divclass = tokenizeDivclass;
 
-  /* Run it just before `paragraph`. */
-  methods.splice(methods.indexOf('paragraph'), 0, DIVCLASS);
+    /* Run it just before `paragraph`. */
+    methods.splice(methods.indexOf('paragraph'), 0, DIVCLASS);
+  }
 };
 
 module.exports.restorationMethods = {

--- a/src/divclass.js
+++ b/src/divclass.js
@@ -75,48 +75,6 @@ module.exports = function divclass() {
   const methods = Parser.prototype.blockMethods;
   const restorationMethods = Parser.prototype.restorationMethods;
 
-  if (restorationMethods) {
-    restorationMethods.divclass = function(add, node, content, children) {
-      const open = add({
-        type: 'paragraph',
-        children: [
-          {
-            type: 'rawtext', // use rawtext rather than text to avoid escaping the `[`
-            value: `[${node.redactionData}]`
-          }
-        ]
-      });
-
-      // Restored divclasses must always have a child; otherwise, an empty
-      // restored divclass would look like `[classname]\n\n[/classname]` which is
-      // not recognized by the parser.
-      // See the test "divclass render works without content - but only if separated by FOUR newlines".
-      // If the parser can be taught to reliably recognize a divclass without that
-      // requirement, this step can be removed
-      if (!(children && children.length)) {
-        children = [
-          {
-            type: 'text',
-            value: ''
-          }
-        ];
-      }
-      const childNodes = children.map(child => add(child));
-
-      const close = add({
-        type: 'paragraph',
-        children: [
-          {
-            type: 'rawtext',
-            value: `[/${node.redactionData}]`
-          }
-        ]
-      });
-
-      return [open, ...childNodes, close];
-    };
-  }
-
   redact = Parser.prototype.options.redact;
 
   tokenizers.divclass = tokenizeDivclass;

--- a/src/link.js
+++ b/src/link.js
@@ -34,30 +34,6 @@ module.exports = function redactedLink() {
   const Parser = this.Parser;
   const restorationMethods = Parser.prototype.restorationMethods;
 
-  if (restorationMethods) {
-    restorationMethods.link = function(add, node, content) {
-      return add({
-        type: 'link',
-        url: node.redactionData.url,
-        title: node.redactionData.title,
-        children: [
-          {
-            type: 'text',
-            value: content
-          }
-        ]
-      });
-    };
-
-    restorationMethods.image = function(add, node, content) {
-      return add({
-        type: 'image',
-        url: node.redactionData.url,
-        alt: content
-      });
-    };
-  }
-
   // If in redacted mode, run this instead of original link and autolink
   // tokenizers. If running regularly, do nothing special.
   if (!Parser.prototype.options.redact) {

--- a/src/link.js
+++ b/src/link.js
@@ -32,41 +32,42 @@
  */
 module.exports = function redactedLink() {
   const Parser = this.Parser;
-  const restorationMethods = Parser.prototype.restorationMethods;
 
-  // If in redacted mode, run this instead of original link and autolink
-  // tokenizers. If running regularly, do nothing special.
-  if (!Parser.prototype.options.redact) {
-    return;
-  }
-
-  const tokenizers = Parser.prototype.inlineTokenizers;
-
-  // override links
-  const originalLinkTokenizer = tokenizers.link;
-  tokenizers.link = function(eat, value, silent) {
-    const link = originalLinkTokenizer.call(this, eat, value, silent);
-    if (!link) {
+  if (Parser) {
+    // If in redacted mode, run this instead of original link and autolink
+    // tokenizers. If running regularly, do nothing special.
+    if (!Parser.prototype.options.redact) {
       return;
     }
 
-    if (link.type === 'link') {
-      redactLink(link);
-    } else if (link.type === 'image') {
-      redactImage(link);
-    }
-  };
-  tokenizers.link.locator = originalLinkTokenizer.locator;
+    const tokenizers = Parser.prototype.inlineTokenizers;
 
-  // override autolinks
-  const originalAutoLinkTokenizer = tokenizers.autoLink;
-  tokenizers.autoLink = function(eat, value, silent) {
-    const autoLink = originalAutoLinkTokenizer.call(this, eat, value, silent);
-    if (autoLink) {
-      redactLink(autoLink);
-    }
-  };
-  tokenizers.autoLink.locator = originalAutoLinkTokenizer.locator;
+    // override links
+    const originalLinkTokenizer = tokenizers.link;
+    tokenizers.link = function(eat, value, silent) {
+      const link = originalLinkTokenizer.call(this, eat, value, silent);
+      if (!link) {
+        return;
+      }
+
+      if (link.type === 'link') {
+        redactLink(link);
+      } else if (link.type === 'image') {
+        redactImage(link);
+      }
+    };
+    tokenizers.link.locator = originalLinkTokenizer.locator;
+
+    // override autolinks
+    const originalAutoLinkTokenizer = tokenizers.autoLink;
+    tokenizers.autoLink = function(eat, value, silent) {
+      const autoLink = originalAutoLinkTokenizer.call(this, eat, value, silent);
+      if (autoLink) {
+        redactLink(autoLink);
+      }
+    };
+    tokenizers.autoLink.locator = originalAutoLinkTokenizer.locator;
+  }
 };
 
 function redactLink(node) {

--- a/src/resourcelink.js
+++ b/src/resourcelink.js
@@ -19,15 +19,6 @@ module.exports = function resourcelink() {
     redact = Parser.prototype.options.redact;
     Parser.prototype.inlineTokenizers[RESOURCELINK] = tokenizeResourcelink;
 
-    if (Parser.prototype.restorationMethods) {
-      Parser.prototype.restorationMethods[RESOURCELINK] = function(add, node) {
-        return add({
-          type: 'rawtext',
-          value: `[r ${node.redactionData}]`
-        });
-      };
-    }
-
     // Run it just before `html`
     const methods = Parser.prototype.inlineMethods;
     methods.splice(methods.indexOf('html'), 0, RESOURCELINK);

--- a/src/tip.js
+++ b/src/tip.js
@@ -7,16 +7,18 @@ const TIP = 'tip';
 
 module.exports = function tip() {
   const Parser = this.Parser;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-  const restorationMethods = Parser.prototype.restorationMethods;
 
-  redact = Parser.prototype.options.redact;
+  if (Parser) {
+    const tokenizers = Parser.prototype.blockTokenizers;
+    const methods = Parser.prototype.blockMethods;
 
-  tokenizers[TIP] = tokenizeTip;
+    redact = Parser.prototype.options.redact;
 
-  /* Run it just before `paragraph`. */
-  methods.splice(methods.indexOf('paragraph'), 0, TIP);
+    tokenizers.tip = tokenizeTip;
+
+    /* Run it just before `paragraph`. */
+    methods.splice(methods.indexOf('paragraph'), 0, 'tip');
+  }
 };
 
 module.exports.restorationMethods = {

--- a/src/tip.js
+++ b/src/tip.js
@@ -11,31 +11,6 @@ module.exports = function tip() {
   const methods = Parser.prototype.blockMethods;
   const restorationMethods = Parser.prototype.restorationMethods;
 
-  if (restorationMethods) {
-    restorationMethods[TIP] = function(add, node, content, children) {
-      let value = `!!!${node.redactionData.tipType}`;
-      if (content) {
-        value += ` "${content}"`;
-      }
-      if (node.redactionData.id) {
-        value += ` <${node.redactionData.id}>`;
-      }
-      return add({
-        type: 'paragraph',
-        children: [
-          {
-            type: 'rawtext',
-            value: value + '\n'
-          },
-          {
-            type: 'indent',
-            children
-          }
-        ]
-      });
-    };
-  }
-
   redact = Parser.prototype.options.redact;
 
   tokenizers[TIP] = tokenizeTip;

--- a/src/tiplink.js
+++ b/src/tiplink.js
@@ -14,17 +14,6 @@ module.exports = function mention() {
     const methods = Parser.prototype.inlineMethods;
     const restorationMethods = Parser.prototype.restorationMethods;
 
-    if (restorationMethods) {
-      restorationMethods[TIPLINK] = function(add, node) {
-        return add({
-          type: 'text',
-          value: `${node.redactionData.tipType}!!! ${
-            node.redactionData.tipLink
-          }`
-        });
-      };
-    }
-
     redact = Parser.prototype.options.redact;
 
     /* Add an inline tokenizer (defined in the following example). */

--- a/src/tiplink.js
+++ b/src/tiplink.js
@@ -12,7 +12,6 @@ module.exports = function mention() {
     const Parser = this.Parser;
     const tokenizers = Parser.prototype.inlineTokenizers;
     const methods = Parser.prototype.inlineMethods;
-    const restorationMethods = Parser.prototype.restorationMethods;
 
     redact = Parser.prototype.options.redact;
 

--- a/src/vocablink.js
+++ b/src/vocablink.js
@@ -19,23 +19,6 @@ module.exports = function vocablink() {
     redact = Parser.prototype.options.redact;
     Parser.prototype.inlineTokenizers[VOCABLINK] = tokenizeVocablink;
 
-    if (Parser.prototype.restorationMethods) {
-      Parser.prototype.restorationMethods[VOCABLINK] = function(
-        add,
-        node,
-        content
-      ) {
-        let value = `[v ${node.redactionData}]`;
-        if (content) {
-          value += `[${content}]`;
-        }
-        return add({
-          type: 'rawtext',
-          value
-        });
-      };
-    }
-
     // Run it just before `html`
     const methods = Parser.prototype.inlineMethods;
     methods.splice(methods.indexOf('html'), 0, VOCABLINK);

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,8 +2,8 @@ const unified = require('unified');
 const stringify = require('remark-stringify');
 const markdown = require('remark-parse');
 const html = require('remark-html');
+const {redact, restore, parseRestorations} = require('remark-redactable');
 const rawtext = require('../src/rawtext');
-const {redact, restore} = require('remark-redactable');
 
 module.exports.markdownToSyntaxTree = (source, plugin = null) =>
   unified()
@@ -32,18 +32,31 @@ module.exports.sourceAndRedactedToRestored = (
   redacted,
   plugin = null
 ) => {
+  let restorationMethods;
+  if (plugin.length) {
+    restorationMethods = plugin
+      .map(p => p.restorationMethods)
+      .reduce((acc, val) => Object.assign({}, acc, val), {});
+  } else {
+    restorationMethods = plugin.restorationMethods;
+  }
   const redactedSourceTree = unified()
     .use(markdown, {commonmark: true})
     .use(redact)
     .use(plugin)
     .parse(source);
+  const restorationTree = unified()
+    .use(markdown, {commomark: true})
+    .use(parseRestorations)
+    .parse(redacted);
+  const mergedTree = unified()
+    .use(restore, redactedSourceTree, restorationMethods)
+    .runSync(restorationTree);
   return unified()
-    .use(markdown, {commonmark: true})
-    .use(restore(redactedSourceTree))
     .use(stringify)
-    .use(plugin)
     .use(rawtext)
-    .processSync(redacted).contents;
+    .use(plugin)
+    .stringify(mergedTree);
 };
 
 module.exports.sourceAndRedactedToHtml = (source, redacted, plugin = null) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,7 @@ const unified = require('unified');
 const stringify = require('remark-stringify');
 const markdown = require('remark-parse');
 const html = require('remark-html');
-const {redact, restore, parseRestorations} = require('remark-redactable');
+const {redact, restore, parseRestorations, renderRestorations} = require('remark-redactable');
 const rawtext = require('../src/rawtext');
 
 module.exports.markdownToSyntaxTree = (source, plugin = null) =>
@@ -55,6 +55,7 @@ module.exports.sourceAndRedactedToRestored = (
   return unified()
     .use(stringify)
     .use(rawtext)
+    .use(renderRestorations)
     .use(plugin)
     .stringify(mergedTree);
 };


### PR DESCRIPTION
Defining these methods in two places will only lead to confusion so let's remove the ones we no longer need.