### PR TITLE
tiplinks should render as spans, not paragraphs

### DIFF
--- a/src/tiplink.js
+++ b/src/tiplink.js
@@ -40,6 +40,7 @@ function createTiplink(add, tipType, tipLink) {
     type: 'paragraph',
     children: [],
     data: {
+      hName: 'span',
       hProperties: {
         className: `tiplink tiplink-${tipType}`
       }

--- a/test/tiplink.test.js
+++ b/test/tiplink.test.js
@@ -11,15 +11,15 @@ const tiplink = require('../src/tiplink');
 
 const basicTipMarkdown = 'tip!!!';
 const basicTipHtml =
-  '<p class="tiplink tiplink-tip"><a href="#tip_undefined"><i class="fa fa-lightbulb-o"></i></a></p>';
+  '<span class="tiplink tiplink-tip"><a href="#tip_undefined"><i class="fa fa-lightbulb-o"></i></a></span>';
 
 const basicDiscussionMarkdown = 'discussion!!!';
 const basicDiscussionHtml =
-  '<p class="tiplink tiplink-discussion"><a href="#discussion_undefined"><i class="fa fa-comments"></i></a></p>';
+  '<span class="tiplink tiplink-discussion"><a href="#discussion_undefined"><i class="fa fa-comments"></i></a></span>';
 
 const labeledTipMarkdown = 'tip!!! tip-0';
 const labeledTipHtml =
-  '<p class="tiplink tiplink-tip"><a href="#tip_tip-0"><i class="fa fa-lightbulb-o"></i></a></p>';
+  '<span class="tiplink tiplink-tip"><a href="#tip_tip-0"><i class="fa fa-lightbulb-o"></i></a></span>';
 
 test('tiplink plugin renders basic tiplink', t => {
   t.plan(1);


### PR DESCRIPTION
See the original plugin: https://github.com/code-dot-org/curriculumbuilder/blob/fca4111b2ad6141d5de51611ffba82784d0beed7/curriculumBuilder/tiplinks.py#L9