### PR TITLE
Misc fixes to the "tips" plugin

### DIFF
--- a/src/tip.js
+++ b/src/tip.js
@@ -5,6 +5,25 @@ const removeIndentation = require("remark-parse/lib/util/remove-indentation");
 const RE = /^!!! ?([\w-]+)(?: "(.*?)")?(?: <(.*?)>)?\n/;
 const TIP = "tip";
 
+const ICON_CLASS = {
+  tip: "fa fa-lightbulb-o",
+  discussion: "fa fa-comments",
+  slide: "fa fa-list-alt",
+  assessment: "fa fa-check-circle",
+  content: "fa fa-mortar-board",
+  say: "fa fa-microphone",
+  guide: "fa fa-pencil-square-o"
+};
+
+const DEFAULT_TITLE = {
+  tip: "Teaching Tip",
+  discussion: "Discussion Goal",
+  slide: "Slide",
+  assessment: "Assessment Opportunity",
+  content: "Content Corner",
+  say: "Remarks"
+};
+
 module.exports = function tip() {
   const Parser = this.Parser;
 
@@ -78,7 +97,7 @@ function tokenizeTip(eat, value, silent) {
   }
 
   const tipType = match[1];
-  const title = match[2] || "";
+  const title = match[2] || DEFAULT_TITLE[tipType] || "";
   const id = match[3];
   const subvalue = value.slice(match[0].length, index);
   const children = this.tokenizeBlock(
@@ -105,42 +124,38 @@ function tokenizeTip(eat, value, silent) {
     });
   }
 
-  return add({
-    type: "div",
+  children.unshift({
+    type: "paragraph",
     children: [
       {
-        type: "paragraph",
-        children: [
-          {
-            type: "emphasis",
-            children: [],
-            data: {
-              hName: "i",
-              hProperties: {
-                className: "fa fa-lightbulb-o"
-              }
-            }
-          },
-          {
-            type: "text",
-            value: title
-          }
-        ],
+        type: "emphasis",
+        children: [],
         data: {
+          hName: "i",
           hProperties: {
-            className: "admonition-title",
-            id: id && `tip_${id}`
+            className: ICON_CLASS[tipType]
           }
         }
       },
       {
-        type: "div",
-        children
+        type: "text",
+        value: title
       }
     ],
     data: {
       hProperties: {
-        className: "admonition tip"
+        className: "admonition-title",
+        id: `${tipType}_${id || 'None'}`
+      }
+    }
+  });
+
+  return add({
+    type: "div",
+    children,
+    data: {
+      hProperties: {
+        className: `admonition ${tipType}`
       }
     }
   });

--- a/src/tip.js
+++ b/src/tip.js
@@ -97,7 +97,8 @@ function tokenizeTip(eat, value, silent) {
   }
 
   const tipType = match[1];
-  const title = match[2] || "";
+  const originalTitle = match[2] || "";
+  const displayTitle = originalTitle || DEFAULT_TITLE[tipType];
   const id = match[3];
   const subvalue = value.slice(match[0].length, index);
   const children = this.tokenizeBlock(
@@ -114,7 +115,7 @@ function tokenizeTip(eat, value, silent) {
       redactionContent: [
         {
           type: "text",
-          value: title
+          value: originalTitle
         }
       ],
       redactionData: {
@@ -124,31 +125,33 @@ function tokenizeTip(eat, value, silent) {
     });
   }
 
-  children.unshift({
-    type: "paragraph",
-    children: [
-      {
-        type: "emphasis",
-        children: [],
-        data: {
-          hName: "i",
-          hProperties: {
-            className: ICON_CLASS[tipType]
+  if (displayTitle) {
+    children.unshift({
+      type: "paragraph",
+      children: [
+        {
+          type: "emphasis",
+          children: [],
+          data: {
+            hName: "i",
+            hProperties: {
+              className: ICON_CLASS[tipType]
+            }
           }
+        },
+        {
+          type: "text",
+          value: displayTitle
         }
-      },
-      {
-        type: "text",
-        value: title || DEFAULT_TITLE[tipType]
+      ],
+      data: {
+        hProperties: {
+          className: "admonition-title",
+          id: `${tipType}_${id || 'None'}`
+        }
       }
-    ],
-    data: {
-      hProperties: {
-        className: "admonition-title",
-        id: `${tipType}_${id || 'None'}`
-      }
-    }
-  });
+    });
+  }
 
   return add({
     type: "div",

--- a/src/tip.js
+++ b/src/tip.js
@@ -1,9 +1,9 @@
 let redact;
 
-const removeIndentation = require('remark-parse/lib/util/remove-indentation');
+const removeIndentation = require("remark-parse/lib/util/remove-indentation");
 
 const RE = /^!!! ?([\w-]+)(?: "(.*?)")?(?: <(.*?)>)?\n/;
-const TIP = 'tip';
+const TIP = "tip";
 
 module.exports = function tip() {
   const Parser = this.Parser;
@@ -17,7 +17,7 @@ module.exports = function tip() {
     tokenizers.tip = tokenizeTip;
 
     /* Run it just before `paragraph`. */
-    methods.splice(methods.indexOf('paragraph'), 0, 'tip');
+    methods.splice(methods.indexOf("paragraph"), 0, "tip");
   }
 };
 
@@ -31,14 +31,14 @@ module.exports.restorationMethods = {
       value += ` <${node.redactionData.id}>`;
     }
     return {
-      type: 'paragraph',
+      type: "paragraph",
       children: [
         {
-          type: 'rawtext',
-          value: value + '\n'
+          type: "rawtext",
+          value: value + "\n"
         },
         {
-          type: 'indent',
+          type: "indent",
           children
         }
       ]
@@ -66,11 +66,11 @@ function tokenizeTip(eat, value, silent) {
   let index = match[0].length;
   while (index < value.length) {
     index++;
-    if (value.charAt(index) === '\n') {
-      if (value.charAt(index + 1) !== '\n') {
+    if (value.charAt(index) === "\n") {
+      if (value.charAt(index + 1) !== "\n") {
         let nextLine = value.slice(index + 1, index + 5);
-        nextLine = nextLine.replace('\t', '    ');
-        if (!nextLine.startsWith('    ')) {
+        nextLine = nextLine.replace("\t", "    ");
+        if (!nextLine.startsWith("    ")) {
           break;
         }
       }
@@ -78,7 +78,7 @@ function tokenizeTip(eat, value, silent) {
   }
 
   const tipType = match[1];
-  const title = match[2] || '';
+  const title = match[2] || "";
   const id = match[3];
   const subvalue = value.slice(match[0].length, index);
   const children = this.tokenizeBlock(
@@ -89,12 +89,12 @@ function tokenizeTip(eat, value, silent) {
 
   if (redact) {
     return add({
-      type: 'blockRedaction',
+      type: "blockRedaction",
       children,
-      redactionType: 'tip',
+      redactionType: "tip",
       redactionContent: [
         {
-          type: 'text',
+          type: "text",
           value: title
         }
       ],
@@ -106,41 +106,41 @@ function tokenizeTip(eat, value, silent) {
   }
 
   return add({
-    type: 'div',
+    type: "div",
     children: [
       {
-        type: 'paragraph',
+        type: "paragraph",
         children: [
           {
-            type: 'emphasis',
+            type: "emphasis",
             children: [],
             data: {
-              hName: 'i',
+              hName: "i",
               hProperties: {
-                className: 'fa fa-lightbulb-o'
+                className: "fa fa-lightbulb-o"
               }
             }
           },
           {
-            type: 'text',
+            type: "text",
             value: title
           }
         ],
         data: {
           hProperties: {
-            className: 'admonition-title',
+            className: "admonition-title",
             id: id && `tip_${id}`
           }
         }
       },
       {
-        type: 'div',
+        type: "div",
         children
       }
     ],
     data: {
       hProperties: {
-        className: 'admonition tip'
+        className: "admonition tip"
       }
     }
   });

--- a/src/tip.js
+++ b/src/tip.js
@@ -97,7 +97,7 @@ function tokenizeTip(eat, value, silent) {
   }
 
   const tipType = match[1];
-  const title = match[2] || DEFAULT_TITLE[tipType] || "";
+  const title = match[2] || "";
   const id = match[3];
   const subvalue = value.slice(match[0].length, index);
   const children = this.tokenizeBlock(
@@ -139,7 +139,7 @@ function tokenizeTip(eat, value, silent) {
       },
       {
         type: "text",
-        value: title
+        value: title || DEFAULT_TITLE[tipType]
       }
     ],
     data: {

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -1,15 +1,15 @@
-const test = require('tape');
+const test = require("tape");
 
 const {
   markdownToHtml,
   markdownToRedacted,
   sourceAndRedactedToRestored
-} = require('./utils');
+} = require("./utils");
 
-const tip = require('../src/tip');
-const indent = require('../src/indent');
+const tip = require("../src/tip");
+const indent = require("../src/indent");
 
-test('tip plugin renders a basic tip', t => {
+test("tip plugin renders a basic tip", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -33,7 +33,7 @@ test('tip plugin renders a basic tip', t => {
   t.equal(output, expected);
 });
 
-test('tip plugin renders a basic tip even with weird indentation', t => {
+test("tip plugin renders a basic tip even with weird indentation", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n\tThis is the content of the tip, and it should be translatable, as should all the following blocks:\n \tone\n\t\t\t\ttwo\n \t three\n              four\n\nThis is the next paragraph';
@@ -58,7 +58,7 @@ test('tip plugin renders a basic tip even with weird indentation', t => {
   t.equal(output, expected);
 });
 
-test('tip plugin renders a basic tip without an id', t => {
+test("tip plugin renders a basic tip without an id", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -68,17 +68,17 @@ test('tip plugin renders a basic tip without an id', t => {
   t.equal(output, expected);
 });
 
-test('tip plugin renders a basic tip without a title', t => {
+test("tip plugin renders a basic tip without a title", t => {
   t.plan(1);
   const input =
-    '!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
+    "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
   const output = markdownToHtml(input, tip);
   const expected =
     '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i></p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
-test('tip plugin renders a tip with multiple children', t => {
+test("tip plugin renders a tip with multiple children", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -105,7 +105,7 @@ test('tip plugin renders a tip with multiple children', t => {
   t.equal(output, expected);
 });
 
-test('tip plugin renders a basic tip indented with tabs', t => {
+test("tip plugin renders a basic tip indented with tabs", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n\tThis is the content of the tip, and it should be translatable\n\tThis is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -129,7 +129,7 @@ test('tip plugin renders a basic tip indented with tabs', t => {
   t.equal(output, expected);
 });
 
-test('tip plugin can redact a basic tip', t => {
+test("tip plugin can redact a basic tip", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -146,33 +146,33 @@ test('tip plugin can redact a basic tip', t => {
    */
   t.equal(
     output,
-    '[this is an optional title, and it should be translatable][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n'
+    "[this is an optional title, and it should be translatable][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n"
   );
 });
 
-test('tip plugin can redact a basic tip without an id', t => {
+test("tip plugin can redact a basic tip without an id", t => {
   t.plan(1);
   const input =
     '!!!tip "this is an optional title, and it should be translatable"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToRedacted(input, tip);
   t.equal(
     output,
-    '[this is an optional title, and it should be translatable][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n'
+    "[this is an optional title, and it should be translatable][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n"
   );
 });
 
-test('tip plugin can redact a basic tip without a title', t => {
+test("tip plugin can redact a basic tip without a title", t => {
   t.plan(1);
   const input =
-    '!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
+    "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
   const output = markdownToRedacted(input, tip);
   t.equal(
     output,
-    '[][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n'
+    "[][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n"
   );
 });
 
-test('tip plugin can restore a basic tip', t => {
+test("tip plugin can restore a basic tip", t => {
   t.plan(1);
   const source =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -180,11 +180,11 @@ test('tip plugin can restore a basic tip', t => {
     "[c'est une optional title, and it should be translatable][0]\n\nC'est du content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
   const output = sourceAndRedactedToRestored(source, redacted, [tip, indent]);
   const expected =
-    '!!!tip "c\'est une optional title, and it should be translatable" <tip-0>\n    C\'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n';
+    "!!!tip \"c'est une optional title, and it should be translatable\" <tip-0>\n    C'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
   t.equal(output, expected);
 });
 
-test('tip plugin can restore a basic tip with multiple children', t => {
+test("tip plugin can restore a basic tip with multiple children", t => {
   t.plan(1);
   const source =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -192,11 +192,11 @@ test('tip plugin can restore a basic tip with multiple children', t => {
     "[c'est une optional title, and it should be translatable][0]\n\nC'est du content of the tip, and it should be translatable\n\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
   const output = sourceAndRedactedToRestored(source, redacted, [tip, indent]);
   const expected =
-    '!!!tip "c\'est une optional title, and it should be translatable" <tip-0>\n    C\'est du content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n';
+    "!!!tip \"c'est une optional title, and it should be translatable\" <tip-0>\n    C'est du content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
   t.equal(output, expected);
 });
 
-test('tip plugin can restore a basic tip without an id', t => {
+test("tip plugin can restore a basic tip without an id", t => {
   t.plan(1);
   const source =
     '!!!tip "this is an optional title, and it should be translatable"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
@@ -204,15 +204,15 @@ test('tip plugin can restore a basic tip without an id', t => {
     "[c'est une optional title, and it should be translatable][0]\n\nC'est du content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
   const output = sourceAndRedactedToRestored(source, redacted, [tip, indent]);
   const expected =
-    '!!!tip "c\'est une optional title, and it should be translatable"\n    C\'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n';
+    "!!!tip \"c'est une optional title, and it should be translatable\"\n    C'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
   t.equal(output, expected);
 });
 
-test('tip plugin can restore a basic tip without a title', t => {
+test("tip plugin can restore a basic tip without a title", t => {
   t.plan(1);
   t.plan(1);
   const source =
-    '!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
+    "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
   const redacted =
     "[][0]\n\nC'est du content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
   const output = sourceAndRedactedToRestored(source, redacted, [tip, indent]);

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -20,16 +20,14 @@ test("tip plugin renders a basic tip", t => {
    *     <i class="fa fa-lightbulb-o"></i>
    *     this is an optional title, and it should be translatable
    *   </p>
-   *   <div>
-   *     <p>
-   *       This is the content of the tip, and it should be translatable This is more stuff that is still part of the content of the tip
-   *     </p>
-   *   </div>
+   *   <p>
+   *     This is the content of the tip, and it should be translatable This is more stuff that is still part of the content of the tip
+   *   </p>
    * </div>
    * <p>This is the next paragraph</p>
    */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -44,17 +42,15 @@ test("tip plugin renders a basic tip even with weird indentation", t => {
    *     <i class="fa fa-lightbulb-o"></i>
    *     this is an optional title, and it should be translatable
    *   </p>
-   *   <div>
-   *     <p>
-   *       This is the content of the tip, and it should be translatable, as
-   *       should all the following blocks: one two three four
-   *     </p>
-   *   </div>
+   *   <p>
+   *     This is the content of the tip, and it should be translatable, as
+   *     should all the following blocks: one two three four
+   *   </p>
    * </div>
    * <p>This is the next paragraph</p>
    */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p></div></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -63,8 +59,21 @@ test("tip plugin renders a basic tip without an id", t => {
   const input =
     '!!!tip "this is an optional title, and it should be translatable"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
+  /**
+   * <div class="admonition tip">
+   *   <p class="admonition-title" id="tip_None">
+   *     <i class="fa fa-lightbulb-o"></i>
+   *     this is an optional title, and it should be translatable
+   *   </p>
+   *   <p>
+   *     This is the content of the tip, and it should be translatable
+   *     This is more stuff that is still part of the content of the tip
+   *   </p>
+   * </div>
+   * <p>This is the next paragraph</p>
+   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip"><p class="admonition-title" id="tip_None"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -73,8 +82,21 @@ test("tip plugin renders a basic tip without a title", t => {
   const input =
     "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
   const output = markdownToHtml(input, tip);
+  /**
+   * <div class="admonition tip">
+   *   <p class="admonition-title" id="tip_tip-0">
+   *     <i class="fa fa-lightbulb-o"></i>
+   *     Teaching Tip
+   *   </p>
+   *   <p>
+   *     This is the content of the tip, and it should be translatable
+   *     This is more stuff that is still part of the content of the tip
+   *   </p>
+   * </div>
+   * <p>This is the next paragraph</p>
+   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i></p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>Teaching Tip</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -89,19 +111,17 @@ test("tip plugin renders a tip with multiple children", t => {
    *     <i class="fa fa-lightbulb-o"></i>
    *     this is an optional title, and it should be translatable
    *   </p>
-   *   <div>
-   *     <p>
-   *       This is the content of the tip, and it should be translatable
-   *     </p>
-   *     <p>
-   *       This is more stuff that is still part of the content of the tip
-   *     </p>
-   *   </div>
+   *   <p>
+   *     This is the content of the tip, and it should be translatable
+   *   </p>
+   *   <p>
+   *     This is more stuff that is still part of the content of the tip
+   *   </p>
    * </div>
    * <p>This is the next paragraph</p>
    */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable</p><p>This is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable</p><p>This is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -111,21 +131,20 @@ test("tip plugin renders a basic tip indented with tabs", t => {
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n\tThis is the content of the tip, and it should be translatable\n\tThis is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
   /*
-       <div class="admonition tip">
-         <p class="admonition-title" id="tip_tip-0">
-           <i class="fa fa-lightbulb-o"></i>
-           this is an optional title, and it should be translatable
-         </p>
-         <div>
-           <p>
-             This is the content of the tip, and it should be translatable This is more stuff that is still part of the content of the tip
-           </p>
-         </div>
-       </div>
-       <p>This is the next paragraph</p>
-       */
+    <div class="admonition tip">
+      <p class="admonition-title" id="tip_tip-0">
+        <i class="fa fa-lightbulb-o"></i>
+        this is an optional title, and it should be translatable
+      </p>
+      <p>
+        This is the content of the tip, and it should be translatable
+        This is more stuff that is still part of the content of the tip
+      </p>
+    </div>
+    <p>This is the next paragraph</p>
+  */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -148,6 +148,21 @@ test("tip plugin renders a basic tip indented with tabs", t => {
   t.equal(output, expected);
 });
 
+test("tip plugin does not render title paragraph unless there is a title", t => {
+  // Guides have no default title, and the current logic will only render the
+  // paragraph containing both the icon and the title text if there is a title,
+  // so a guide without a title will render without an icon.
+  //
+  // This test is meant to document current behavior, not to comment on desired
+  // behavior; we do in fact probably want to fix this behavior in the long
+  // term.
+  t.plan(1);
+  const input = "!!!guide <content-0>\n\n\tinner content";
+  const output = markdownToHtml(input, tip);
+  const expected = '<div class="admonition guide"><p>inner content</p></div>\n';
+  t.equal(output, expected);
+});
+
 test("tip plugin can redact a basic tip", t => {
   t.plan(1);
   const input =


### PR DESCRIPTION
- run Prettier
- add support for icons and default titles: https://github.com/code-dot-org/curriculumbuilder/blob/fca4111b2ad6141d5de51611ffba82784d0beed7/curriculumBuilder/tips.py#L87-L107
- tweak the logic around how child elements are wrapped in inner divs


Because of the Prettier changes, it'll likely be easiest to review only the functional commits: https://github.com/code-dot-org/remark-plugins/pull/25/files/e8ea940b2078366dd71302d89615f484bf852147..8a2c9336fcc6df80a6e2a8a7ca387025944fc222