### PR TITLE
Match remark's behaviors to python-markdown

### DIFF
--- a/src/tip.js
+++ b/src/tip.js
@@ -101,18 +101,21 @@ function tokenizeTip(eat, value, silent) {
   const displayTitle = originalTitle || DEFAULT_TITLE[tipType];
   const id = match[3];
   const subvalue = value.slice(match[0].length, index);
-  // hacky: add a new line character at the beginning of subvalue
+
+  // The original python-markdown renderer for CurriculumBuilder renders an empty div if
+  // there is a newline between title and body. We want to emulate that behavior here by
+  // adding a new line character at the beginning of the subvalue. If the subvalue begins
+  // with 2 newline characters, it will be treated by the split below as an empty block,
+  // and therefore will be rendered as an empty div.
   const subvalueBlock = removeIndentation('\n' + subvalue, 4).split('\n\n');
 
-  let children = [];
-  subvalueBlock.forEach(block => {
-    children.push({
-      type: "div",
-      children: this.tokenizeBlock(
-        block,
-        eat.now())
+  const children = subvalueBlock.map(block => ({
+    type: "div",
+    children: this.tokenizeBlock(
+      block,
+      eat.now())
     })
-  });
+  );
 
   const add = eat(match[0] + subvalue);
 

--- a/src/tip.js
+++ b/src/tip.js
@@ -58,12 +58,28 @@ module.exports.restorationMethods = {
         },
         {
           type: "indent",
-          children
+          children: expandTipBodyChildren(children)
         }
       ]
     };
   }
 };
+
+/***
+ * In the tokenizeTip method below, there is a special logic to wrap the body
+ * children in divs using newline separation. This method reverses that logic
+ * to restore the original markdown.
+ */
+function expandTipBodyChildren(children) {
+  return children.reduce((accumulator, currentValue, index) => {
+    if (currentValue.type == 'div') {
+      accumulator = accumulator.concat(currentValue.children);
+    } else {
+      accumulator.push(currentValue);
+    }
+    return accumulator;
+  }, []);
+}
 
 function tokenizeTip(eat, value, silent) {
   const match = RE.exec(value);
@@ -110,7 +126,7 @@ function tokenizeTip(eat, value, silent) {
   const subvalueBlock = removeIndentation('\n' + subvalue, 4).split(/[\n]{2,}/);
 
   const children = subvalueBlock.map(block => ({
-    type: "div",
+    type: 'div',
     children: this.tokenizeBlock(
       block,
       eat.now())
@@ -122,7 +138,7 @@ function tokenizeTip(eat, value, silent) {
   if (redact) {
     return add({
       type: "blockRedaction",
-      children,
+      children: expandTipBodyChildren(children),
       redactionType: "tip",
       redactionContent: [
         {

--- a/src/tip.js
+++ b/src/tip.js
@@ -101,10 +101,19 @@ function tokenizeTip(eat, value, silent) {
   const displayTitle = originalTitle || DEFAULT_TITLE[tipType];
   const id = match[3];
   const subvalue = value.slice(match[0].length, index);
-  const children = this.tokenizeBlock(
-    removeIndentation(subvalue, 4),
-    eat.now()
-  );
+  // hacky: add a new line character at the beginning of subvalue
+  const subvalueBlock = removeIndentation('\n' + subvalue, 4).split('\n\n');
+
+  let children = [];
+  subvalueBlock.forEach(block => {
+    children.push({
+      type: "div",
+      children: this.tokenizeBlock(
+        block,
+        eat.now())
+    })
+  });
+
   const add = eat(match[0] + subvalue);
 
   if (redact) {

--- a/src/tip.js
+++ b/src/tip.js
@@ -105,9 +105,9 @@ function tokenizeTip(eat, value, silent) {
   // The original python-markdown renderer for CurriculumBuilder renders an empty div if
   // there is a newline between title and body. We want to emulate that behavior here by
   // adding a new line character at the beginning of the subvalue. If the subvalue begins
-  // with 2 newline characters, it will be treated by the split below as an empty block,
-  // and therefore will be rendered as an empty div.
-  const subvalueBlock = removeIndentation('\n' + subvalue, 4).split('\n\n');
+  // with 2 or more newline characters, it will be treated by the split below as an empty
+  // block, and therefore will be rendered as an empty div.
+  const subvalueBlock = removeIndentation('\n' + subvalue, 4).split(/[\n]{2,}/);
 
   const children = subvalueBlock.map(block => ({
     type: "div",

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -14,20 +14,14 @@ test("tip plugin renders a basic tip", t => {
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
-  /**
-   * <div class="admonition tip">
-   *   <p class="admonition-title" id="tip_tip-0">
-   *     <i class="fa fa-lightbulb-o"></i>
-   *     this is an optional title, and it should be translatable
-   *   </p>
-   *   <p>
-   *     This is the content of the tip, and it should be translatable This is more stuff that is still part of the content of the tip
-   *   </p>
-   * </div>
-   * <p>This is the next paragraph</p>
-   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip">' +
+        '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+        '<div>' +
+            '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+        '</div>' +
+    '</div>\n' +
+    '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -36,21 +30,14 @@ test("tip plugin renders a basic tip even with weird indentation", t => {
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n\tThis is the content of the tip, and it should be translatable, as should all the following blocks:\n \tone\n\t\t\t\ttwo\n \t three\n              four\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
-  /**
-   * <div class="admonition tip">
-   *   <p class="admonition-title" id="tip_tip-0">
-   *     <i class="fa fa-lightbulb-o"></i>
-   *     this is an optional title, and it should be translatable
-   *   </p>
-   *   <p>
-   *     This is the content of the tip, and it should be translatable, as
-   *     should all the following blocks: one two three four
-   *   </p>
-   * </div>
-   * <p>This is the next paragraph</p>
-   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip">' +
+        '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+        '<div>' +
+            '<p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p>' +
+        '</div>' +
+    '</div>\n' +
+    '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -59,21 +46,14 @@ test("tip plugin renders a basic tip without an id", t => {
   const input =
     '!!!tip "this is an optional title, and it should be translatable"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
-  /**
-   * <div class="admonition tip">
-   *   <p class="admonition-title" id="tip_None">
-   *     <i class="fa fa-lightbulb-o"></i>
-   *     this is an optional title, and it should be translatable
-   *   </p>
-   *   <p>
-   *     This is the content of the tip, and it should be translatable
-   *     This is more stuff that is still part of the content of the tip
-   *   </p>
-   * </div>
-   * <p>This is the next paragraph</p>
-   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_None"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip">' +
+        '<p class="admonition-title" id="tip_None"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+        '<div>' +
+            '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+        '</div>' +
+    '</div>\n' +
+    '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -82,21 +62,14 @@ test("tip plugin renders a basic tip without a title", t => {
   const input =
     "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
   const output = markdownToHtml(input, tip);
-  /**
-   * <div class="admonition tip">
-   *   <p class="admonition-title" id="tip_tip-0">
-   *     <i class="fa fa-lightbulb-o"></i>
-   *     Teaching Tip
-   *   </p>
-   *   <p>
-   *     This is the content of the tip, and it should be translatable
-   *     This is more stuff that is still part of the content of the tip
-   *   </p>
-   * </div>
-   * <p>This is the next paragraph</p>
-   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>Teaching Tip</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
+      '<div class="admonition tip">' +
+          '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>Teaching Tip</p>' +
+          '<div>' +
+              '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+          '</div>' +
+      '</div>\n' +
+      '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -105,23 +78,17 @@ test("tip plugin renders a tip with multiple children", t => {
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
-  /**
-   * <div class="admonition tip">
-   *   <p class="admonition-title" id="tip_tip-0">
-   *     <i class="fa fa-lightbulb-o"></i>
-   *     this is an optional title, and it should be translatable
-   *   </p>
-   *   <p>
-   *     This is the content of the tip, and it should be translatable
-   *   </p>
-   *   <p>
-   *     This is more stuff that is still part of the content of the tip
-   *   </p>
-   * </div>
-   * <p>This is the next paragraph</p>
-   */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable</p><p>This is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
+      '<div class="admonition tip">' +
+          '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+          '<div>' +
+              '<p>This is the content of the tip, and it should be translatable</p>' +
+          '</div>' +
+          '<div>' +
+              '<p>This is more stuff that is still part of the content of the tip</p>' +
+          '</div>' +
+      '</div>\n' +
+      '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -130,21 +97,14 @@ test("tip plugin renders a basic tip indented with tabs", t => {
   const input =
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n\tThis is the content of the tip, and it should be translatable\n\tThis is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
-  /*
-    <div class="admonition tip">
-      <p class="admonition-title" id="tip_tip-0">
-        <i class="fa fa-lightbulb-o"></i>
-        this is an optional title, and it should be translatable
-      </p>
-      <p>
-        This is the content of the tip, and it should be translatable
-        This is more stuff that is still part of the content of the tip
-      </p>
-    </div>
-    <p>This is the next paragraph</p>
-  */
   const expected =
-    '<div class="admonition tip"><p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div>\n<p>This is the next paragraph</p>\n';
+      '<div class="admonition tip">' +
+          '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+          '<div>' +
+              '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+          '</div>' +
+      '</div>\n' +
+      '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -159,7 +119,7 @@ test("tip plugin does not render title paragraph unless there is a title", t => 
   t.plan(1);
   const input = "!!!guide <content-0>\n\n\tinner content";
   const output = markdownToHtml(input, tip);
-  const expected = '<div class="admonition guide"><p>inner content</p></div>\n';
+  const expected = '<div class="admonition guide"><div></div><div><p>inner content</p></div></div>\n';
   t.equal(output, expected);
 });
 

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -254,3 +254,41 @@ test("tip plugin can restore a basic tip without a title", t => {
     "!!!tip <tip-0>\n    C'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
   t.equal(output, expected);
 });
+
+test("tip plugin renders two paragraphs with a blank line in between ", t => {
+  t.plan(1);
+  const input =
+    '!!!guide <content-0>\n' +
+    '\n' +
+    '    # a header\n' +
+    '    \n' +
+    '    a paragraph\n';
+  const output = markdownToHtml(input, tip);
+  const expected =
+    '<div class="admonition guide">' +
+      '<div></div>' +
+      '<div>' +
+        '<h1>a header</h1>' +
+      '</div>' +
+      '<div>' +
+        '<p>a paragraph</p>' +
+      '</div>' +
+    '</div>\n';
+  t.equal(output, expected);
+});
+
+test("tip plugin renders no blank line between title and paragraph", t => {
+  t.plan(1)
+  const input =
+    '!!!guide <content-0>\n' +
+    '    The only paragraph\n';
+  const output = markdownToHtml(input, tip);
+  const expected =
+    '<div class="admonition guide">' +
+      '<div>' +
+        '<p>The only paragraph</p>' +
+      '</div>' +
+    '</div>\n'
+  ;
+  t.equal(output, expected);
+});

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -215,16 +215,16 @@ test("tip plugin can restore a basic tip without a title", t => {
   t.equal(output, expected);
 });
 
-test("tip plugin renders two paragraphs with a blank line in between ", t => {
-  t.plan(1);
-  const input =
+test("tip plugin wraps newline-separated children in individual divs", t => {
+  t.plan(2);
+  const inputWithNewLine =
     '!!!guide <content-0>\n' +
     '\n' +
     '    # a header\n' +
     '    \n' +
     '    a paragraph\n';
-  const output = markdownToHtml(input, tip);
-  const expected =
+  const outputWithNewLine = markdownToHtml(inputWithNewLine, tip);
+  const expectedWithNewLine =
     '<div class="admonition guide">' +
       '<div></div>' +
       '<div>' +
@@ -234,21 +234,54 @@ test("tip plugin renders two paragraphs with a blank line in between ", t => {
         '<p>a paragraph</p>' +
       '</div>' +
     '</div>\n';
-  t.equal(output, expected);
+  t.equal(outputWithNewLine, expectedWithNewLine);
+
+  // otherwise
+  const inputWithoutNewLine =
+    '!!!guide <content-0>\n' +
+    '\n' +
+    '    # a header\n' +
+    '    a paragraph\n';
+  const outputWithoutNewLine = markdownToHtml(inputWithoutNewLine, tip);
+  const expectedWithoutNewLine =
+    '<div class="admonition guide">' +
+      '<div></div>' +
+      '<div>' +
+        '<h1>a header</h1>' +
+        '<p>a paragraph</p>' +
+      '</div>' +
+    '</div>\n';
+  t.equal(outputWithoutNewLine, expectedWithoutNewLine);
 });
 
-test("tip plugin renders no blank line between title and paragraph", t => {
-  t.plan(1)
-  const input =
+test("tip plugin renders an empty div when there is a newline between title and body", t => {
+  t.plan(2)
+  const inputWithoutNewLine =
     '!!!guide <content-0>\n' +
     '    The only paragraph\n';
-  const output = markdownToHtml(input, tip);
-  const expected =
+  const outputWithoutNewLine = markdownToHtml(inputWithoutNewLine, tip);
+  const expectedWithoutNewLine =
     '<div class="admonition guide">' +
       '<div>' +
         '<p>The only paragraph</p>' +
       '</div>' +
     '</div>\n'
   ;
-  t.equal(output, expected);
+  t.equal(outputWithoutNewLine, expectedWithoutNewLine);
+
+  // otherwise
+  const inputWithNewLine =
+    '!!!guide <content-0>\n' +
+    '\n' +
+    '    The only paragraph\n';
+  const outputWithNewLine = markdownToHtml(inputWithNewLine, tip);
+  const expectedWithNewLine =
+    '<div class="admonition guide">' +
+      '<div></div>' +
+      '<div>' +
+        '<p>The only paragraph</p>' +
+      '</div>' +
+    '</div>\n'
+  ;
+  t.equal(outputWithNewLine, expectedWithNewLine);
 });

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -285,3 +285,50 @@ test("tip plugin renders an empty div when there is a newline between title and 
   ;
   t.equal(outputWithNewLine, expectedWithNewLine);
 });
+
+test("tip plugin restoration preserves extra newline", t => {
+  t.plan(1);
+  const source =
+    '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n' +
+    '\n' +
+    '    This is the content of the tip, and it should be translatable\n' +
+    '    \n' +
+    '    This is more stuff that is still part of the content of the tip\n';
+
+  const redacted =
+    "[c'est une optional title, and it should be translatable][0]\n" +
+    "\n" +
+    "C'est du content of the tip, and it should be translatable\n" +
+    "\n" +
+    "This is more stuff that is still part of the content of the tip\n" +
+    "\n" +
+    "[/][0]\n";
+
+  const output = sourceAndRedactedToRestored(source, redacted, [tip, indent]);
+  const expected =
+    "!!!tip \"c'est une optional title, and it should be translatable\" <tip-0>\n" +
+    "    C'est du content of the tip, and it should be translatable\n" +
+    "\n" +
+    "    This is more stuff that is still part of the content of the tip\n"
+  t.equal(output, expected);
+});
+
+test("tip plugin redaction preserves extra newline", t => {
+  t.plan(1);
+  const input =
+    '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n' +
+    '    This is the content of the tip, and it should be translatable\n' +
+    '    \n' +
+    '    This is more stuff that is still part of the content of the tip\n';
+  const output = markdownToRedacted(input, tip);
+  t.equal(
+    output,
+    '[this is an optional title, and it should be translatable][0]\n' +
+    '\n' +
+    'This is the content of the tip, and it should be translatable\n' +
+    '\n' +
+    'This is more stuff that is still part of the content of the tip\n' +
+    '\n' +
+    '[/][0]\n'
+  );
+});

--- a/test/tip.test.js
+++ b/test/tip.test.js
@@ -16,10 +16,10 @@ test("tip plugin renders a basic tip", t => {
   const output = markdownToHtml(input, tip);
   const expected =
     '<div class="admonition tip">' +
-        '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
-        '<div>' +
-            '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
-        '</div>' +
+      '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+      '<div>' +
+        '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+      '</div>' +
     '</div>\n' +
     '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
@@ -32,10 +32,10 @@ test("tip plugin renders a basic tip even with weird indentation", t => {
   const output = markdownToHtml(input, tip);
   const expected =
     '<div class="admonition tip">' +
-        '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
-        '<div>' +
-            '<p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p>' +
-        '</div>' +
+      '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+      '<div>' +
+        '<p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p>' +
+      '</div>' +
     '</div>\n' +
     '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
@@ -48,10 +48,10 @@ test("tip plugin renders a basic tip without an id", t => {
   const output = markdownToHtml(input, tip);
   const expected =
     '<div class="admonition tip">' +
-        '<p class="admonition-title" id="tip_None"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
-        '<div>' +
-            '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
-        '</div>' +
+      '<p class="admonition-title" id="tip_None"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+      '<div>' +
+        '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+      '</div>' +
     '</div>\n' +
     '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
@@ -63,13 +63,13 @@ test("tip plugin renders a basic tip without a title", t => {
     "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
   const output = markdownToHtml(input, tip);
   const expected =
-      '<div class="admonition tip">' +
-          '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>Teaching Tip</p>' +
-          '<div>' +
-              '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
-          '</div>' +
-      '</div>\n' +
-      '<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip">' +
+      '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>Teaching Tip</p>' +
+      '<div>' +
+        '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+      '</div>' +
+    '</div>\n' +
+    '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -79,16 +79,16 @@ test("tip plugin renders a tip with multiple children", t => {
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n    This is the content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
   const expected =
-      '<div class="admonition tip">' +
-          '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
-          '<div>' +
-              '<p>This is the content of the tip, and it should be translatable</p>' +
-          '</div>' +
-          '<div>' +
-              '<p>This is more stuff that is still part of the content of the tip</p>' +
-          '</div>' +
-      '</div>\n' +
-      '<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip">' +
+      '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+      '<div>' +
+        '<p>This is the content of the tip, and it should be translatable</p>' +
+      '</div>' +
+      '<div>' +
+        '<p>This is more stuff that is still part of the content of the tip</p>' +
+      '</div>' +
+    '</div>\n' +
+    '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 
@@ -98,13 +98,13 @@ test("tip plugin renders a basic tip indented with tabs", t => {
     '!!!tip "this is an optional title, and it should be translatable" <tip-0>\n\tThis is the content of the tip, and it should be translatable\n\tThis is more stuff that is still part of the content of the tip\n\nThis is the next paragraph';
   const output = markdownToHtml(input, tip);
   const expected =
-      '<div class="admonition tip">' +
-          '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
-          '<div>' +
-              '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
-          '</div>' +
-      '</div>\n' +
-      '<p>This is the next paragraph</p>\n';
+    '<div class="admonition tip">' +
+      '<p class="admonition-title" id="tip_tip-0"><i class="fa fa-lightbulb-o"></i>this is an optional title, and it should be translatable</p>' +
+      '<div>' +
+        '<p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p>' +
+      '</div>' +
+    '</div>\n' +
+    '<p>This is the next paragraph</p>\n';
   t.equal(output, expected);
 });
 


### PR DESCRIPTION
[FND-1219](https://codedotorg.atlassian.net/browse/FND-1219): Paired with @Hamms to update remark-plugin behaviors to match that of python-markdown. See https://github.com/code-dot-org/curriculumbuilder/pull/301 PR for recently-added python-markdown tests.

2 new behaviors are:
* If a tip body contains multiple new-line separated elements, the remark-plugin will wrap them in individual divs.
* If there is a newline between title and body of the tip, the remark-plugin will render an empty div for that newline.

Side-effect of adding those new behaviors are:
* Updating redaction and restoration code to assure their `children` inputs don't change.
* Adding 2 new tests to verify that redaction and restoration code still work correctly.
* Updating the expected outputs of most of the existing tests.


