### PR TITLE
Stop using named capture groups

### DIFF
--- a/src/resourceLink.js
+++ b/src/resourceLink.js
@@ -1,6 +1,6 @@
 let redact;
 
-const RESOURCE_LINK_RE = /^\[r (?<resource>[a-z0-9\-\_]+)\/(?<offering>[a-z\-]+)\/(?<version>\d+)\]/;
+const RESOURCE_LINK_RE = /^\[r ([a-z0-9\-\_]+)\/([a-z\-]+)\/(\d+)\]/;
 const RESOURCE_LINK = 'resourceLink';
 
 /**
@@ -53,13 +53,19 @@ function tokenizeResourceLink(eat, value, silent) {
   const add = eat(match[0]);
 
   if (redact) {
+    const redactionData = {
+      resource: match[1],
+      offering: match[2],
+      version: match[3],
+    };
+
     return add({
       type: 'inlineRedaction',
       redactionType: RESOURCE_LINK,
-      redactionData: match.groups,
+      redactionData,
       redactionContent: [{
         type: 'text',
-        value: match.groups.resource
+        value: redactionData.resource
       }]
     });
   } else {

--- a/src/vocabularyDefinition.js
+++ b/src/vocabularyDefinition.js
@@ -1,6 +1,6 @@
 let redact;
 
-const VOCAB_DEFINITION_RE = /^\[v (?<vocabulary>[a-z_]+)\/(?<offering>[a-z\-]+)\/(?<version>\d+)\]/;
+const VOCAB_DEFINITION_RE = /^\[v ([a-z_]+)\/([a-z\-]+)\/(\d+)\]/;
 const VOCAB_DEFINITION = 'vocabularyDefinition';
 
 /**
@@ -53,13 +53,19 @@ function tokenizeVocabularyDefinition(eat, value, silent) {
   const add = eat(match[0]);
 
   if (redact) {
+    const redactionData = {
+      vocabulary: match[1],
+      offering: match[2],
+      version: match[3],
+    };
+
     return add({
       type: 'inlineRedaction',
       redactionType: VOCAB_DEFINITION,
-      redactionData: match.groups,
+      redactionData,
       redactionContent: [{
         type: 'text',
-        value: match.groups.vocabulary
+        value: redactionData.vocabulary
       }]
     });
   } else {


### PR DESCRIPTION
So that we work on older versions of node, which don't support this feature. We could alternatively transpile this for release or even probably add a transpilation step for the part of our codebase that includes this, but this is easier.