### PR TITLE
retaining the children of link nodes in redaction

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -82,7 +82,6 @@ function redactLink(node) {
   delete node.title;
 
   node.redactionContent = node.children;
-  delete node.children;
 }
 
 function redactImage(node) {
@@ -112,7 +111,7 @@ module.exports.restorationMethods = {
       children: [
         {
           type: 'text',
-          value: content
+          value: content ? content : ''
         }
       ]
     };


### PR DESCRIPTION
Related to https://github.com/code-dot-org/remark-redactable/pull/15, we want to retain the children of link redaction nodes so that, during restoration, our `visit` function can correctly traverse the nodes of the syntax tree. The `visit` function does not detect the children stored in `redactionContent`.

Additionally added a null check for translated content.