### PR TITLE
updating remark-redactable to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/remark-plugins",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/remark-plugins",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Library of all Remark plugins we use",
   "main": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^5.16.0",
     "remark-html": "^9.0.0",
     "remark-parse": "^6.0.3",
-    "remark-redactable": "1.0.0",
+    "remark-redactable": "1.3.0",
     "remark-stringify": "^6.0.4",
     "tape": "^4.10.2",
     "unified": "^7.1.0",


### PR DESCRIPTION
updating the remark-redactable version to pick up recent changes to parsing logic