### PR TITLE
null check for link children

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -117,7 +117,7 @@ module.exports.restorationMethods = {
       type: 'link',
       url: node.redactionData.url,
       title: node.redactionData.title,
-      children: children
+      children: children || []
     };
   },
   image: function(node, content) {


### PR DESCRIPTION
When testing an i18n sync dry run locally, the restoration during sync out failed due to the following errors:

```
(node:75216) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
    at Of.all (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/all.js:9:25)
    at Of.link (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/visitors/link.js:42:20)
    at Of.one [as visit] (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/one.js:19:30)
    at Of.all (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/all.js:14:27)
    at Of.emphasis (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/visitors/emphasis.js:25:22)
    at Of.one [as visit] (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/one.js:19:30)
    at Of.all (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/all.js:14:27)
    at Of.paragraph (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/visitors/paragraph.js:6:15)
    at Of.one [as visit] (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/one.js:19:30)
    at Of.block (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/block.js:50:22)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:75216) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:75216) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:75311) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
    at Of.all (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/all.js:9:25)
    at Of.link (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/visitors/link.js:42:20)
    at Of.one [as visit] (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/one.js:19:30)
    at Of.all (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/all.js:14:27)
    at Of.paragraph (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/visitors/paragraph.js:6:15)
    at Of.one [as visit] (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/one.js:19:30)
    at Of.block (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/block.js:50:22)
    at Of.root (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/visitors/root.js:10:15)
    at Of.one [as visit] (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/one.js:19:30)
    at Of.compile (/Users/annaxu/code-dot-org/bin/i18n/node_modules/remark-stringify/lib/macro/compile.js:9:15)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:75311) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:75311) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Sync out failed from the error: JSON::ParserError: A JSON text must at least contain two octets!
bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
Parallel::UndumpableException: JSON::ParserError: A JSON text must at least contain two octets!
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/json-1.8.6/lib/json/common.rb:155:in `initialize'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/json-1.8.6/lib/json/common.rb:155:in `new'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/json-1.8.6/lib/json/common.rb:155:in `parse'
  /Users/annaxu/code-dot-org/bin/i18n/redact_restore_utils.rb:29:in `restore_file'
  /Users/annaxu/code-dot-org/bin/i18n/sync-out.rb:149:in `block (2 levels) in restore_redacted_files'
  /Users/annaxu/code-dot-org/bin/i18n/sync-out.rb:136:in `each'
  /Users/annaxu/code-dot-org/bin/i18n/sync-out.rb:136:in `block in restore_redacted_files'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:486:in `call_with_index'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:455:in `process_incoming_jobs'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:437:in `block in worker'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:428:in `fork'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:428:in `worker'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:419:in `block in create_workers'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:418:in `each'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:418:in `each_with_index'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:418:in `create_workers'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:358:in `work_in_processes'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:264:in `map'
  /Users/annaxu/code-dot-org/vendor/bundle/ruby/2.5.0/gems/parallel-1.12.1/lib/parallel.rb:217:in `each'
  /Users/annaxu/code-dot-org/bin/i18n/sync-out.rb:131:in `restore_redacted_files'
  /Users/annaxu/code-dot-org/bin/i18n/sync-out.rb:26:in `sync_out'
  /Users/annaxu/code-dot-org/bin/i18n/sync-all.rb:67:in `run'
  /Users/annaxu/code-dot-org/bin/i18n/sync-all.rb:162:in `<top (required)>'
```

This error occurred because the link restoration process operates on a `children` property, and we have instances of links without children (example: `[](https://studio.code.org/api/v1/animation-library/gamelab/_Fss9nfE5lNH0kxcazbNg2Dxl7rbZDBA/category_fantasy/alien_13.png)`). This PR adds a null check on the children property during link restoration.

Jira: https://codedotorg.atlassian.net/browse/FND-1763?atlOrigin=eyJpIjoiOGZkYjI5NTEzZTE3NDFlZGI5YTA3Mjc4NjI3MjlhZjYiLCJwIjoiaiJ9
  
This change was tested by locally running the i18n sync in, down, and out and verifying that known nested redactions (image links) get correctly restored.

Follow up tasks: update all 3 redaction/restoration libraries (`remark-plugins`, `remark-redactable`, `redactable-markdown`) with patches, and update the code-dot-org repo with the correct version.