### PR TITLE
adding start_html plugin

### DIFF
--- a/src/startHtml.js
+++ b/src/startHtml.js
@@ -1,0 +1,84 @@
+/**
+ * start_html
+ *
+ * This plugin redacts all HTML tags and content in a start_html level string,
+ * such that the translator only sees the relevant text to translate.
+ *
+ * @example
+ * Source: <label
+ *          style="margin: 0px; padding: 2px;
+ *              line-height: 1; font-size: 40px;
+ *              overflow: hidden; word-wrap: break-word;
+ *              color: rgb(51, 51, 51);
+ *              max-width: 320px; width: 320px; height: 45px;
+ *              position: absolute; left: 0px; top: 15px;
+ *              text-align: center;"
+ *           id="label3">
+ *           Success!
+ *         </label>
+ * Redacted: [][0]Success![][1]
+ */
+
+let redact;
+const HTML_TAG_RE = /<\/{0,1}[a-zA-Z]+(>|.*?[^?]>)/;
+const START_HTML = 'startHtml';
+
+module.exports = function startHtml() {
+  if (this.Parser) {
+    const Parser = this.Parser;
+    redact = Parser.prototype.options.redact
+
+    Parser.prototype.inlineTokenizers[START_HTML] = tokenizeStartHtml;
+
+    // redact start_html before the parser tries to parse text as HTML
+    const methods = Parser.prototype.inlineMethods;
+    methods.splice(methods.indexOf('html'), 0, START_HTML);
+  }
+};
+
+tokenizeStartHtml.notInLink = true;
+tokenizeStartHtml.locator = locateStartHtml;
+
+function tokenizeStartHtml(eat, value, silent) {
+  const match = HTML_TAG_RE.exec(value);
+
+  if (!match || value.indexOf(match[0]) != 0) {
+    return;
+  }
+
+  if (silent) {
+    return true;
+  }
+
+  console.log("match[0]: " + match[0]);
+  console.log("value: " + value);
+  const add = eat(match[0]);
+
+  if (redact) {
+    return add({
+      type: 'inlineRedaction',
+      redactionType: START_HTML,
+      redactionData: match[0],
+      redactionContent: [{
+        type: 'text',
+        value: ''
+      }]
+    });
+  }
+
+  return false;
+
+}
+
+function locateStartHtml(value, fromIndex) {
+  return value.indexOf('<', fromIndex);
+}
+
+module.exports.restorationMethods = {
+  [START_HTML]: function(node) {
+    return {
+      type: 'rawtext',
+      value: node.redactionData
+    }
+  }
+}

--- a/src/startHtml.js
+++ b/src/startHtml.js
@@ -49,9 +49,7 @@ function tokenizeStartHtml(eat, value, silent) {
   if (silent) {
     return true;
   }
-
-  console.log("match[0]: " + match[0]);
-  console.log("value: " + value);
+  
   const add = eat(match[0]);
 
   if (redact) {

--- a/src/startHtml.js
+++ b/src/startHtml.js
@@ -4,6 +4,10 @@
  * This plugin redacts all HTML tags and content in a start_html level string,
  * such that the translator only sees the relevant text to translate.
  *
+ * NOTE: this plugin does not support the redaction or restoration of <div>
+ *   tags, because Remark does not parse them to begin with
+ *   issue: https://github.com/remarkjs/remark/issues/185
+ *
  * @example
  * Source: <label
  *          style="margin: 0px; padding: 2px;
@@ -49,7 +53,7 @@ function tokenizeStartHtml(eat, value, silent) {
   if (silent) {
     return true;
   }
-  
+
   const add = eat(match[0]);
 
   if (redact) {

--- a/test/startHtml.test.js
+++ b/test/startHtml.test.js
@@ -1,0 +1,29 @@
+const test = require("tape");
+
+const {markdownToRedacted, sourceAndRedactedToRestored} = require('./utils');
+
+const startHtml = require("../src/startHtml");
+
+test('startHtml plugin can redact inline', t => {
+  t.plan(1);
+  const markdown =
+    '<label style="margin: 0px; padding: 2px;" id="label3">some label</label>';
+  const expected =
+    '[][0]some label[][1]\n'
+
+  const rendered = markdownToRedacted(markdown, startHtml);
+  t.equal(rendered, expected);
+});
+
+test('startHtml plugin can restore', t => {
+  t.plan(1);
+  const source =
+    '<label style="margin: 0px; padding: 2px;" id="label3">some label</label>';
+  const translated =
+    '[][0]alguna etiqueta[][1]';
+  const expected =
+    '<label style="margin: 0px; padding: 2px;" id="label3">alguna etiqueta</label>\n';
+
+  const rendered = sourceAndRedactedToRestored(source, translated, startHtml);
+  t.equal(rendered, expected);
+})

--- a/test/startHtml.test.js
+++ b/test/startHtml.test.js
@@ -7,9 +7,24 @@ const startHtml = require("../src/startHtml");
 test('startHtml plugin can redact inline', t => {
   t.plan(1);
   const markdown =
-    '<label style="margin: 0px; padding: 2px;" id="label3">some label</label>';
+    '<label style="margin: 0px; padding: 2px;" id="label3">' +
+    'some label' +
+    '</label>';
   const expected =
-    '[][0]some label[][1]\n'
+    '[][0]some label[][1]\n';
+
+  const rendered = markdownToRedacted(markdown, startHtml);
+  t.equal(rendered, expected);
+});
+
+test('startHtml plugin can redact nested html', t => {
+  t.plan(1);
+  const markdown =
+    '<button><button style="margin: 0px; padding: 2px;" id="label3">' +
+    'some label inside a button' +
+    '</button></button>';
+  const expected =
+    '[][0][][1]some label inside a button[][2][][3]\n';
 
   const rendered = markdownToRedacted(markdown, startHtml);
   t.equal(rendered, expected);
@@ -26,4 +41,6 @@ test('startHtml plugin can restore', t => {
 
   const rendered = sourceAndRedactedToRestored(source, translated, startHtml);
   t.equal(rendered, expected);
-})
+});
+
+


### PR DESCRIPTION
Jira: https://codedotorg.atlassian.net/browse/FND-2094?atlOrigin=eyJpIjoiZWM1Mjg3YWE0OGRjNDFlN2IyN2M2NDE3N2NiZWI3NGIiLCJwIjoiaiJ9 

This PR creates the redaction and restoration plugin for the `start_html` attribute for Applab starter and sample apps. The plugin redacts each opening and closing tag as their own inline redaction node, and restores the HTML after translation. 2 unit tests have been written for redaction and restoration.

Example: 

`<button id="purpleButton" style="padding: 0px; margin: 0px; height: 20px; width: 75px; font-size: 14px; color: rgb(255, 255, 255); background-color: rgb(26, 188, 156); position: absolute; left: 65px; top: 315px; border-style: solid; border-width: 0px; border-color: rgb(0, 0, 0); border-radius: 0px; font-family: Arial, Helvetica, sans-serif;">Purple</button>
`
would be redacted to:
`[][0]Purple[][1]`