### PR TITLE
Clickable text support

### DIFF
--- a/src/clickableText.js
+++ b/src/clickableText.js
@@ -8,15 +8,16 @@
  *   <b data-id="id" class="clickable-text">text</b>
  */
 
+const CLICKABLETEXT_RE = /#clickable=(.*)/;
+
 module.exports = function clickableText() {
   const Parser = this.Parser;
   const tokenizers = Parser.prototype.inlineTokenizers;
-  const originalText = tokenizers.link;
+  const originalLinkTokenizer = tokenizers.link;
   tokenizers.link = function (eat, value, silent) {
-    const link = originalText.call(this, eat, value, silent);
+    const link = originalLinkTokenizer.call(this, eat, value, silent);
     if (link && link.url && link.url.startsWith("#clickable=")) {
-      const regexp = /#clickable=(.*)/;
-      const matches = link.url.match(regexp);
+      const matches = link.url.match(CLICKABLETEXT_RE);
       if (matches && matches.length === 2) {
         const id = matches[1];
 
@@ -33,5 +34,5 @@ module.exports = function clickableText() {
 
     return link;
   };
-  tokenizers.link.locator = originalText.locator;
+  tokenizers.link.locator = originalLinkTokenizer.locator;
 };

--- a/src/clickableText.js
+++ b/src/clickableText.js
@@ -1,0 +1,37 @@
+/**
+ * Support for clickable text in instructions.
+ *
+ * When the text markdown contains:
+ *   [text](#clickable=id)
+ *
+ * This code will generate
+ *   <b data-id="id" class="clickable-text">text</b>
+ */
+
+module.exports = function clickableText() {
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.inlineTokenizers;
+  const originalText = tokenizers.link;
+  tokenizers.link = function (eat, value, silent) {
+    const link = originalText.call(this, eat, value, silent);
+    if (link && link.url && link.url.startsWith("#clickable=")) {
+      const regexp = /#clickable=(.*)/;
+      const matches = link.url.match(regexp);
+      if (matches?.length === 2) {
+        const id = matches[1];
+
+        link.type = "b";
+        link.data = {
+          hName: "b",
+          hProperties: {
+            dataId: id,
+            className: "clickable-text",
+          },
+        };
+      }
+    }
+
+    return link;
+  };
+  tokenizers.link.locator = originalText.locator;
+};

--- a/src/clickableText.js
+++ b/src/clickableText.js
@@ -17,7 +17,7 @@ module.exports = function clickableText() {
     if (link && link.url && link.url.startsWith("#clickable=")) {
       const regexp = /#clickable=(.*)/;
       const matches = link.url.match(regexp);
-      if (matches?.length === 2) {
+      if (matches && matches.length === 2) {
         const id = matches[1];
 
         link.type = "b";

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const blockfield = require("./blockfield");
 const blockly = require("./blockly");
+const clickableText = require("./clickableText");
 const codestudio = require("./codestudio");
 const details = require("./details");
 const div = require("./div");
@@ -19,6 +20,7 @@ const xmlAsTopLevelBlock = require("./xmlAsTopLevelBlock");
 module.exports = {
   blockfield,
   blockly,
+  clickableText,
   codestudio,
   details,
   div,

--- a/test/clickableText.test.js
+++ b/test/clickableText.test.js
@@ -11,3 +11,12 @@ test("clickable text is converted", (t) => {
   const rendered = markdownToHtml(markdown, clickableText);
   t.equal(rendered, expected);
 });
+
+test("regular link is not converted", (t) => {
+  t.plan(1);
+  const markdown = "before [middle](#other=myid) after";
+  const expected = '<p>before <a href="#other=myid">middle</a> after</p>\n';
+
+  const rendered = markdownToHtml(markdown, clickableText);
+  t.equal(rendered, expected);
+});

--- a/test/clickableText.test.js
+++ b/test/clickableText.test.js
@@ -1,0 +1,13 @@
+const test = require("tape");
+const { markdownToHtml } = require("./utils");
+const clickableText = require("../src/clickableText");
+
+test("clickable text is converted", (t) => {
+  t.plan(1);
+  const markdown = "before [middle](#clickable=myid) after";
+  const expected =
+    '<p>before <b data-id="myid" class="clickable-text">middle</b> after</p>\n';
+
+  const rendered = markdownToHtml(markdown, clickableText);
+  t.equal(rendered, expected);
+});


### PR DESCRIPTION
This adds support for clickable text.

When the text markdown contains:
```
[text](#clickable=id)
```
This code will generate:
 ```
<b data-id="id" class="clickable-text">text</b>
```

The main repo will make use of this functionality in https://github.com/code-dot-org/code-dot-org/pull/55861.

